### PR TITLE
Setup Docker Compose with Flask app and MySQL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY src/ /app
+CMD ["python", "app.py"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
 # Attanasio-DB-system
-Nothing here, go away
+
+This project contains a MySQL schema and a small Flask application. The
+application exposes a couple of endpoints and connects to the MySQL database.
+Both services are orchestrated via Docker Compose.
+
+## Requirements
+
+- Docker with Compose support
+
+## Usage
+
+Build and start the environment:
+
+```bash
+docker compose up --build
+```
+
+The database will be initialized using `DockerConfig/DBScript.sql`. The
+Flask server will be available on [http://localhost:5000](http://localhost:5000).
+
+Useful endpoints:
+
+- `/health` – simple health check
+- `/specialists` – returns the list of specialists in the database
+
+To stop the services:
+
+```bash
+docker compose down
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3.8'
+services:
+  db:
+    image: mysql:latest
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: sudopassw
+      MYSQL_DATABASE: Attanasio
+      MYSQL_USER: Antonella
+      MYSQL_PASSWORD: attanasio
+    volumes:
+      - db_data:/var/lib/mysql
+      - ./DockerConfig/DBScript.sql:/docker-entrypoint-initdb.d/1_DBScript.sql
+    ports:
+      - "3306:3306"
+      - "33061:33060"
+  web:
+    build: .
+    environment:
+      MYSQL_HOST: db
+      MYSQL_PORT: 3306
+      MYSQL_DATABASE: Attanasio
+      MYSQL_USER: Antonella
+      MYSQL_PASSWORD: attanasio
+    depends_on:
+      - db
+    ports:
+      - "5000:5000"
+volumes:
+  db_data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask==2.3.2
+mysql-connector-python==8.0.33

--- a/src/app.py
+++ b/src/app.py
@@ -1,0 +1,32 @@
+from flask import Flask, jsonify
+import mysql.connector
+import os
+
+app = Flask(__name__)
+
+def get_db_connection():
+    return mysql.connector.connect(
+        host=os.getenv("MYSQL_HOST", "db"),
+        user=os.getenv("MYSQL_USER", "Antonella"),
+        password=os.getenv("MYSQL_PASSWORD", "attanasio"),
+        database=os.getenv("MYSQL_DATABASE", "Attanasio"),
+        port=int(os.getenv("MYSQL_PORT", "3306")),
+    )
+
+@app.route("/health")
+def health():
+    return {"status": "ok"}
+
+@app.route("/specialists")
+def list_specialists():
+    conn = get_db_connection()
+    cur = conn.cursor(dictionary=True)
+    cur.execute("SELECT * FROM Specialista")
+    results = cur.fetchall()
+    cur.close()
+    conn.close()
+    return jsonify(results)
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000)
+


### PR DESCRIPTION
## Summary
- add Flask application with simple DB endpoint
- create Dockerfile for the Flask service
- provide docker-compose file including MySQL setup
- document usage in README
- add Python requirements file

## Testing
- `python -m py_compile src/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6863b36ec468832fab2e0e72202fbe62