### PR TITLE
Add basic jQuery-based dashboard UI

### DIFF
--- a/src/static/css/style.css
+++ b/src/static/css/style.css
@@ -1,0 +1,10 @@
+body {
+    padding-top: 4.5rem;
+    background-color: #f5f5f5;
+}
+.navbar-brand {
+    font-weight: bold;
+}
+.table-actions {
+    white-space: nowrap;
+}

--- a/src/static/js/main.js
+++ b/src/static/js/main.js
@@ -1,0 +1,52 @@
+$(function() {
+    var csrfToken = $("meta[name='csrf-token']").attr('content');
+    $.ajaxSetup({
+        beforeSend: function(xhr, settings) {
+            if (!/^(GET|HEAD|OPTIONS|TRACE)$/.test(settings.type)) {
+                xhr.setRequestHeader('X-CSRFToken', csrfToken);
+            }
+        }
+    });
+
+    function loadSpecialists() {
+        $.getJSON('/specialists/', function(data) {
+            var rows = data.map(function(item) {
+                return '<tr><td>' + item.id + '</td><td>' + item.nome + '</td><td>' + item.cognome +
+                       '</td><td>' + item.ruolo +
+                       '</td><td class="table-actions"><button class="btn btn-sm btn-danger delete-specialist" data-id="' + item.id + '">Delete</button></td></tr>';
+            }).join('');
+            $('#specialists-table tbody').html(rows);
+        });
+    }
+
+    $('#add-specialist-form').submit(function(e) {
+        e.preventDefault();
+        var data = {
+            nome: $('#specialist-nome').val(),
+            cognome: $('#specialist-cognome').val(),
+            ruolo: $('#specialist-ruolo').val()
+        };
+        $.ajax({
+            url: '/specialists/',
+            method: 'POST',
+            contentType: 'application/json',
+            data: JSON.stringify(data),
+            success: function() {
+                $('#addSpecialistModal').modal('hide');
+                loadSpecialists();
+                $('#add-specialist-form')[0].reset();
+            }
+        });
+    });
+
+    $('#specialists-table').on('click', '.delete-specialist', function() {
+        var id = $(this).data('id');
+        $.ajax({
+            url: '/specialists/' + id,
+            method: 'DELETE',
+            success: loadSpecialists
+        });
+    });
+
+    loadSpecialists();
+});

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <title>{% block title %}Gestionale{% endblock %}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+    {% block head %}{% endblock %}
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="#">Gestionale</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarNav">
+            <ul class="navbar-nav ms-auto">
+                <li class="nav-item"><a class="nav-link" href="{{ url_for('auth.logout') }}">Logout</a></li>
+            </ul>
+        </div>
+    </div>
+</nav>
+<div class="container-fluid mt-4">
+    {% block content %}{% endblock %}
+</div>
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="{{ url_for('static', filename='js/main.js') }}"></script>
+{% block scripts %}{% endblock %}
+</body>
+</html>

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -1,4 +1,46 @@
-<!doctype html>
-<title>Home</title>
-<h2>Benvenuto</h2>
-<p><a href="{{ url_for('auth.logout') }}">Logout</a></p>
+{% extends 'base.html' %}
+{% block title %}Dashboard{% endblock %}
+{% block content %}
+<h1 class="mb-4">Specialisti</h1>
+<table class="table table-striped" id="specialists-table">
+    <thead>
+    <tr>
+        <th>ID</th>
+        <th>Nome</th>
+        <th>Cognome</th>
+        <th>Ruolo</th>
+        <th></th>
+    </tr>
+    </thead>
+    <tbody></tbody>
+</table>
+<button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#addSpecialistModal">Aggiungi Specialista</button>
+
+<div class="modal fade" id="addSpecialistModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Nuovo Specialista</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <form id="add-specialist-form">
+          <div class="mb-3">
+            <label class="form-label">Nome</label>
+            <input type="text" class="form-control" id="specialist-nome" required>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Cognome</label>
+            <input type="text" class="form-control" id="specialist-cognome" required>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Ruolo</label>
+            <input type="text" class="form-control" id="specialist-ruolo" required>
+          </div>
+          <button type="submit" class="btn btn-primary">Salva</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/src/templates/login.html
+++ b/src/templates/login.html
@@ -1,9 +1,21 @@
-<!doctype html>
-<title>Login</title>
-<h2>Login</h2>
-<form method="post">
-    {{ form.hidden_tag() }}
-    <p>{{ form.username.label }} {{ form.username() }}</p>
-    <p>{{ form.password.label }} {{ form.password() }}</p>
-    <p><input type="submit" value="Login"></p>
-</form>
+{% extends 'base.html' %}
+{% block title %}Login{% endblock %}
+{% block content %}
+<div class="row justify-content-center">
+  <div class="col-md-4">
+    <h2 class="mb-3">Login</h2>
+    <form method="post">
+        {{ form.hidden_tag() }}
+        <div class="mb-3">
+            {{ form.username.label(class_='form-label') }}
+            {{ form.username(class_='form-control') }}
+        </div>
+        <div class="mb-3">
+            {{ form.password.label(class_='form-label') }}
+            {{ form.password(class_='form-control') }}
+        </div>
+        <button type="submit" class="btn btn-primary">Accedi</button>
+    </form>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- implement a base Bootstrap layout with jQuery and CSRF token
- enhance login page styling
- add a dashboard page to manage `Specialista` entries via AJAX
- include small CSS and JS assets

## Testing
- `python -m compileall -q src`

------
https://chatgpt.com/codex/tasks/task_e_6863b8d5064c832f858a379f6972d205