### PR TITLE
Bugfix: auto-create Users table

### DIFF
--- a/src/db.py
+++ b/src/db.py
@@ -1,6 +1,32 @@
 import os
 import mysql.connector
 from flask import g
+from werkzeug.security import generate_password_hash
+
+
+def _ensure_users_table(conn):
+    """Create login table and default admin user if missing."""
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS Users (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            username VARCHAR(255) UNIQUE NOT NULL,
+            password_hash VARCHAR(255) NOT NULL
+        )
+        """
+    )
+    conn.commit()
+
+    cur.execute("SELECT COUNT(*) FROM Users")
+    count = cur.fetchone()[0]
+    if count == 0:
+        cur.execute(
+            "INSERT INTO Users (username, password_hash) VALUES (%s, %s)",
+            ("admin", generate_password_hash("admin123")),
+        )
+        conn.commit()
+    cur.close()
 
 
 def get_db_connection():
@@ -12,6 +38,7 @@ def get_db_connection():
             database=os.getenv('MYSQL_DATABASE', 'Attanasio'),
             port=int(os.getenv('MYSQL_PORT', '3306')),
         )
+        _ensure_users_table(g.db_conn)
     return g.db_conn
 
 


### PR DESCRIPTION
## Summary
- check for `Users` table existence when the DB connection is created
- create the table and insert a default admin user if missing

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863bcbd37fc832f94f6a5a4363f53c3