### PR TITLE
Ensure DB initialization before Flask startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,6 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY src/ /app
-CMD ["python", "app.py"]
+COPY DockerConfig/DBScript.sql /app/DBScript.sql
+RUN chmod +x /app/entrypoint.sh
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       MYSQL_DATABASE: Attanasio
       MYSQL_USER: Antonella
       MYSQL_PASSWORD: attanasio
+      MYSQL_ROOT_PASSWORD: sudopassw
     depends_on:
       - db
     ports:

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+python /app/init_db.py
+exec python /app/app.py

--- a/src/init_db.py
+++ b/src/init_db.py
@@ -1,0 +1,59 @@
+import os
+import time
+import mysql.connector
+
+DB_NAME = os.getenv('MYSQL_DATABASE', 'Attanasio')
+DB_HOST = os.getenv('MYSQL_HOST', 'db')
+DB_PORT = int(os.getenv('MYSQL_PORT', '3306'))
+DB_USER = os.getenv('MYSQL_USER', 'Antonella')
+DB_PASS = os.getenv('MYSQL_PASSWORD', 'attanasio')
+ROOT_PASS = os.getenv('MYSQL_ROOT_PASSWORD', '')
+
+# Use root credentials when available, as some scripts may require it
+USE_ROOT = bool(ROOT_PASS)
+
+def wait_for_db():
+    while True:
+        try:
+            mysql.connector.connect(host=DB_HOST, port=DB_PORT,
+                                   user=DB_USER if not USE_ROOT else 'root',
+                                   password=DB_PASS if not USE_ROOT else ROOT_PASS)
+            return
+        except mysql.connector.Error:
+            time.sleep(2)
+
+def run_sql_script(conn, path):
+    with open(path, 'r') as f:
+        sql = f.read()
+    # remove comment lines
+    lines = []
+    for line in sql.splitlines():
+        striped = line.strip()
+        if not striped.startswith('--'):
+            lines.append(line)
+    sql = '\n'.join(lines)
+    # split statements by semicolon
+    statements = [s.strip() for s in sql.split(';') if s.strip()]
+    cur = conn.cursor()
+    for stmt in statements:
+        cur.execute(stmt)
+    conn.commit()
+    cur.close()
+
+def ensure_tables():
+    conn = mysql.connector.connect(host=DB_HOST, port=DB_PORT,
+                                   user=DB_USER if not USE_ROOT else 'root',
+                                   password=DB_PASS if not USE_ROOT else ROOT_PASS,
+                                   database=DB_NAME)
+    cur = conn.cursor()
+    cur.execute("SHOW TABLES LIKE 'Specialista'")
+    exists = cur.fetchone()
+    if not exists:
+        # run the sql script
+        run_sql_script(conn, '/app/DBScript.sql')
+    cur.close()
+    conn.close()
+
+if __name__ == '__main__':
+    wait_for_db()
+    ensure_tables()


### PR DESCRIPTION
## Summary
- add entrypoint that waits for MySQL and runs DB init script
- copy DBScript.sql and entrypoint in Dockerfile
- expose root password to web service

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `docker compose config` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6863be91c658832f873a0598ec5f531e