### PR TITLE
Add CSV import/export and bulk table tools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 Flask==2.3.2
 mysql-connector-python==8.0.33
 Flask-WTF==1.2.2
+
+openpyxl==3.1.2

--- a/src/app.py
+++ b/src/app.py
@@ -9,6 +9,7 @@ from modules.sede import sede_bp
 from modules.provvedimento import provvedimento_bp
 from modules.users_table import users_table_bp
 from modules.utils import login_required
+from modules.extras import extras_bp
 
 app = Flask(__name__)
 app.config['SECRET_KEY'] = 'change-this-secret'
@@ -24,6 +25,7 @@ app.register_blueprint(afferenza_bp)
 app.register_blueprint(sede_bp)
 app.register_blueprint(provvedimento_bp)
 app.register_blueprint(users_table_bp)
+app.register_blueprint(extras_bp)
 
 
 @app.route('/')

--- a/src/modules/extras.py
+++ b/src/modules/extras.py
@@ -1,0 +1,81 @@
+from flask import Blueprint, request, send_file, jsonify
+from db import get_db_connection
+from .utils import login_required
+from openpyxl import Workbook
+import csv
+import io
+
+# Mapping from endpoint names to database table names
+TABLE_MAP = {
+    'specialists': 'Specialista',
+    'users': 'Utente',
+    'afferenze': 'Afferenza',
+    'sedi': 'Sede',
+    'provvedimenti': 'Provvedimento',
+    'loginusers': 'Users',
+}
+
+extras_bp = Blueprint('extras', __name__, url_prefix='/extras')
+
+
+@extras_bp.route('/export/<name>', methods=['GET'])
+@login_required
+def export_table(name):
+    table = TABLE_MAP.get(name)
+    if not table:
+        return jsonify({'error': 'unknown table'}), 400
+    conn = get_db_connection()
+    cur = conn.cursor(dictionary=True)
+    cur.execute(f'SELECT * FROM {table}')
+    rows = cur.fetchall()
+    cur.close()
+
+    wb = Workbook()
+    ws = wb.active
+    if rows:
+        headers = list(rows[0].keys())
+        ws.append(headers)
+        for r in rows:
+            ws.append([r[h] for h in headers])
+    output = io.BytesIO()
+    wb.save(output)
+    output.seek(0)
+    filename = f'{table}.xlsx'
+    return send_file(output, download_name=filename,
+                     as_attachment=True,
+                     mimetype='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+
+
+@extras_bp.route('/import/<name>', methods=['POST'])
+@login_required
+def import_csv(name):
+    table = TABLE_MAP.get(name)
+    if not table:
+        return jsonify({'error': 'unknown table'}), 400
+    file = request.files.get('file')
+    if not file:
+        return jsonify({'error': 'missing file'}), 400
+
+    stream = io.StringIO(file.stream.read().decode('utf-8'))
+    reader = csv.DictReader(stream)
+    columns = reader.fieldnames
+    if not columns:
+        return jsonify({'error': 'empty csv'}), 400
+
+    conn = get_db_connection()
+    cur = conn.cursor()
+    placeholders = ','.join(['%s'] * len(columns))
+    columns_sql = ','.join(columns)
+    query = f'INSERT INTO {table} ({columns_sql}) VALUES ({placeholders})'
+    try:
+        conn.start_transaction()
+        for row in reader:
+            values = [row.get(c) or None for c in columns]
+            cur.execute(query, values)
+        conn.commit()
+    except Exception as e:
+        conn.rollback()
+        cur.close()
+        return jsonify({'error': str(e)}), 400
+    cur.close()
+    return jsonify({'status': 'imported'})

--- a/src/static/js/main.js
+++ b/src/static/js/main.js
@@ -17,26 +17,109 @@ $(function() {
         loginusers: '/loginusers/'
     };
 
+    var currentTable = 'specialists';
+    var currentColumns = [];
+
     function loadTable(name) {
+        currentTable = name;
         $.getJSON(endpoints[name], function(data) {
             var thead = '';
             var tbody = '';
             if (data.length > 0) {
-                var keys = Object.keys(data[0]);
-                thead = '<tr>' + keys.map(function(k){ return '<th>' + k + '</th>'; }).join('') + '</tr>';
+                currentColumns = Object.keys(data[0]);
+                thead = '<tr><th><input type="checkbox" id="select-all"></th>' +
+                    currentColumns.map(function(k){ return '<th>' + k + '</th>'; }).join('') + '</tr>';
                 tbody = data.map(function(row){
-                    var tds = keys.map(function(k){
+                    var tds = currentColumns.map(function(k){
                         var val = row[k];
                         return '<td>' + (val === null ? '' : val) + '</td>';
                     }).join('');
-                    return '<tr>' + tds + '</tr>';
+                    var dataAttrs = currentColumns.map(function(k){ return 'data-' + k + '="' + row[k] + '"'; }).join(' ');
+                    return '<tr ' + dataAttrs + '><td><input type="checkbox" class="row-check"></td>' + tds + '</tr>';
                 }).join('');
             }
             $('#data-table thead').html(thead);
             $('#data-table tbody').html(tbody);
+            $('#delete-selected').prop('disabled', true);
             $('#search-bar').trigger('keyup');
         });
     }
+
+    $('#data-table').on('change', '.row-check, #select-all', function(){
+        if (this.id === 'select-all') {
+            $('.row-check').prop('checked', this.checked);
+        }
+        $('#delete-selected').prop('disabled', $('#data-table .row-check:checked').length === 0);
+    });
+
+    $('#delete-selected').on('click', function(){
+        var checks = $('#data-table .row-check:checked');
+        if (checks.length === 0) return;
+        checks.each(function(){
+            var row = $(this).closest('tr');
+            var data = row.data();
+            var url = endpoints[currentTable];
+            if (currentTable === 'afferenze') {
+                url += data.utente_id + '/' + data.specialista_id + '/' + data.data_inizio;
+            } else {
+                url += data.id;
+            }
+            $.ajax({url: url, method: 'DELETE'});
+        });
+        loadTable(currentTable);
+    });
+
+    $('#add-row').on('click', function(){
+        var form = $('#add-form');
+        form.empty();
+        currentColumns.forEach(function(c){
+            if (c === 'id') return;
+            form.append('<div class="mb-3"><label class="form-label">'+c+'</label><input class="form-control" name="'+c+'"></div>');
+        });
+        new bootstrap.Modal(document.getElementById('addModal')).show();
+    });
+
+    $('#add-form').on('submit', function(e){
+        e.preventDefault();
+        var data = {};
+        $(this).serializeArray().forEach(function(i){ data[i.name] = i.value; });
+        $.ajax({
+            url: endpoints[currentTable],
+            method: 'POST',
+            contentType: 'application/json',
+            data: JSON.stringify(data)
+        }).done(function(){
+            bootstrap.Modal.getInstance(document.getElementById('addModal')).hide();
+            loadTable(currentTable);
+        });
+    });
+
+    $('#import-csv-btn').on('click', function(){
+        $('#csv-input').val('');
+        new bootstrap.Modal(document.getElementById('importModal')).show();
+    });
+
+    $('#import-form').on('submit', function(e){
+        e.preventDefault();
+        var file = $('#csv-input')[0].files[0];
+        if (!file) return;
+        var formData = new FormData();
+        formData.append('file', file);
+        $.ajax({
+            url: '/extras/import/' + currentTable,
+            method: 'POST',
+            data: formData,
+            processData: false,
+            contentType: false
+        }).done(function(){
+            bootstrap.Modal.getInstance(document.getElementById('importModal')).hide();
+            loadTable(currentTable);
+        });
+    });
+
+    $('#export-excel').on('click', function(){
+        window.location = '/extras/export/' + currentTable;
+    });
 
     $('.table-link').on('click', function(e){
         e.preventDefault();

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -14,10 +14,56 @@
   </div>
   <div class="col-md-10 content-area">
     <input type="text" id="search-bar" class="form-control mb-3" placeholder="Cerca...">
+    <div class="mb-3">
+      <button id="add-row" class="btn btn-primary">Aggiungi</button>
+      <button id="import-csv-btn" class="btn btn-secondary">Import CSV</button>
+      <button id="export-excel" class="btn btn-success">Export Excel</button>
+      <button id="delete-selected" class="btn btn-danger" disabled>&#128465;</button>
+    </div>
     <table class="table table-striped" id="data-table">
       <thead></thead>
       <tbody></tbody>
     </table>
+  </div>
+</div>
+
+<!-- Add record modal -->
+<div class="modal fade" id="addModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <form id="add-form">
+        <div class="modal-header">
+          <h5 class="modal-title">Aggiungi Record</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body"></div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annulla</button>
+          <button type="submit" class="btn btn-primary">Salva</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+
+<!-- Import CSV modal -->
+<div class="modal fade" id="importModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <form id="import-form">
+        <div class="modal-header">
+          <h5 class="modal-title">Importa CSV</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body">
+          <input type="file" id="csv-input" name="file" accept=".csv" class="form-control">
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annulla</button>
+          <button type="submit" class="btn btn-primary">Carica</button>
+        </div>
+      </form>
+    </div>
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- create `extras` blueprint for CSV import and Excel export
- wire up new blueprint in `app.py`
- add table management buttons and modals in dashboard
- handle bulk deletion, CSV import and Excel export in JS
- add `openpyxl` requirement

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68668bfce628832fa4226888d339624b