### PR TITLE
Fix add form when table empty

### DIFF
--- a/src/modules/extras.py
+++ b/src/modules/extras.py
@@ -79,3 +79,19 @@ def import_csv(name):
         return jsonify({'error': str(e)}), 400
     cur.close()
     return jsonify({'status': 'imported'})
+
+
+@extras_bp.route('/columns/<name>', methods=['GET'])
+@login_required
+def get_columns(name):
+    """Return the column names for a given table."""
+    table = TABLE_MAP.get(name)
+    if not table:
+        return jsonify({'error': 'unknown table'}), 400
+
+    conn = get_db_connection()
+    cur = conn.cursor()
+    cur.execute(f"SHOW COLUMNS FROM {table}")
+    columns = [row[0] for row in cur.fetchall()]
+    cur.close()
+    return jsonify(columns)

--- a/src/static/js/main.js
+++ b/src/static/js/main.js
@@ -97,17 +97,28 @@ $(function() {
         });
     });
 
-    $('#add-row').on('click', function(){
+    function showAddModal(cols){
         var form = $('#add-form');
         form.empty();
-        if (currentColumns.length === 0 && allColumns.length === 0) return;
-        var visibleCols = allColumns.length ? orderColumns(allColumns) : currentColumns;
-        visibleCols.forEach(function(c){
+        cols.forEach(function(c){
             if (hiddenColumns.indexOf(c) !== -1) return;
             form.append('<div class="mb-3"><label class="form-label">'+c+'</label><input class="form-control" name="'+c+'"></div>');
         });
-        var modal = new bootstrap.Modal(document.getElementById('addModal'));
-        modal.show();
+        new bootstrap.Modal(document.getElementById('addModal')).show();
+    }
+
+    $('#add-row').on('click', function(){
+        if (currentColumns.length === 0 && allColumns.length === 0) {
+            $.getJSON('/extras/columns/' + currentTable, function(cols){
+                if (!cols.length) return;
+                allColumns = cols;
+                currentColumns = orderColumns(cols);
+                showAddModal(currentColumns);
+            });
+            return;
+        }
+        var visibleCols = allColumns.length ? orderColumns(allColumns) : currentColumns;
+        showAddModal(visibleCols);
     });
 
     $('#add-form').on('submit', function(e){


### PR DESCRIPTION
## Summary
- allow fetching columns for empty tables via new `/extras/columns/<name>` route
- use that endpoint in JS to open the add-row modal when no records exist

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686696bc69b0832f90f882124199d4e3