### PR TITLE
Fix founder add user UI and CSRF

### DIFF
--- a/src/templates/founder_panel.html
+++ b/src/templates/founder_panel.html
@@ -17,17 +17,35 @@
   {% endfor %}
 </table>
 <h3>Aggiungi Utente</h3>
-<form method="post" action="{{ url_for('founder.add_user') }}">
-  <div class="mb-3"><input name="username" class="form-control" placeholder="Username"></div>
-  <div class="mb-3"><input name="email" class="form-control" placeholder="Email"></div>
-  <div class="mb-3"><input name="password" type="password" class="form-control" placeholder="Password"></div>
-  <div class="mb-3">
-    <select name="role" class="form-select">
-      <option value="founder">Founder</option>
-      <option value="editor">Editor</option>
-      <option value="viewer" selected>Visualizzatore</option>
-    </select>
+<button class="btn btn-primary mb-3" data-bs-toggle="modal" data-bs-target="#addUserModal">Aggiungi nuovo utente</button>
+
+<div class="modal fade" id="addUserModal" tabindex="-1" aria-labelledby="addUserModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <form method="post" action="{{ url_for('founder.add_user') }}">
+        <div class="modal-header">
+          <h5 class="modal-title" id="addUserModalLabel">Aggiungi Utente</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+          <div class="mb-3"><input name="username" class="form-control" placeholder="Username"></div>
+          <div class="mb-3"><input name="email" class="form-control" placeholder="Email"></div>
+          <div class="mb-3"><input name="password" type="password" class="form-control" placeholder="Password"></div>
+          <div class="mb-3">
+            <select name="role" class="form-select">
+              <option value="founder">Founder</option>
+              <option value="editor">Editor</option>
+              <option value="viewer" selected>Visualizzatore</option>
+            </select>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Chiudi</button>
+          <button type="submit" class="btn btn-primary">Aggiungi</button>
+        </div>
+      </form>
+    </div>
   </div>
-  <button type="submit" class="btn btn-primary">Aggiungi</button>
-</form>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- show user creation dialog in a modal on founder panel
- include CSRF token inside the modal form

## Testing
- `python -m compileall -q src`

------
https://chatgpt.com/codex/tasks/task_e_6866aa072bf0832fa6b7504d60f60908