### PR TITLE
Add highlighted columns and improved record UI

### DIFF
--- a/DockerConfig/DBScript.sql
+++ b/DockerConfig/DBScript.sql
@@ -147,6 +147,7 @@ CREATE TABLE ColumnConfig (
   id INT AUTO_INCREMENT PRIMARY KEY,
   table_name VARCHAR(255) NOT NULL,
   column_name VARCHAR(255) NOT NULL,
+  highlight BOOLEAN NOT NULL DEFAULT FALSE,
   visible BOOLEAN NOT NULL DEFAULT TRUE,
   display_order INT DEFAULT 0,
   UNIQUE KEY table_col (table_name, column_name)

--- a/src/db.py
+++ b/src/db.py
@@ -55,6 +55,7 @@ def _ensure_users_table(conn):
             id INT AUTO_INCREMENT PRIMARY KEY,
             table_name VARCHAR(255) NOT NULL,
             column_name VARCHAR(255) NOT NULL,
+            highlight BOOLEAN NOT NULL DEFAULT FALSE,
             visible BOOLEAN NOT NULL DEFAULT TRUE,
             display_order INT DEFAULT 0,
             UNIQUE KEY table_col (table_name, column_name)

--- a/src/modules/extras.py
+++ b/src/modules/extras.py
@@ -114,7 +114,7 @@ def get_column_config(name):
     cur = conn.cursor(dictionary=True)
 
     cur.execute(
-        'SELECT column_name, visible, display_order FROM ColumnConfig '
+        'SELECT column_name, visible, display_order, highlight FROM ColumnConfig '
         'WHERE table_name=%s ORDER BY display_order',
         (table,)
     )
@@ -140,8 +140,14 @@ def set_column_config(name):
         cur.execute('DELETE FROM ColumnConfig WHERE table_name=%s', (table,))
         for idx, col in enumerate(columns):
             cur.execute(
-                'INSERT INTO ColumnConfig (table_name, column_name, visible, display_order) VALUES (%s,%s,%s,%s)',
-                (table, col.get('column_name'), bool(col.get('visible', True)), int(col.get('display_order', idx)))
+                'INSERT INTO ColumnConfig (table_name, column_name, highlight, visible, display_order) VALUES (%s,%s,%s,%s,%s)',
+                (
+                    table,
+                    col.get('column_name'),
+                    bool(col.get('highlight', False)),
+                    bool(col.get('visible', True)),
+                    int(col.get('display_order', idx)),
+                )
             )
         conn.commit()
     except Exception as e:

--- a/src/modules/record.py
+++ b/src/modules/record.py
@@ -5,6 +5,15 @@ from db import get_db_connection
 from .utils import login_required
 from .query_builder import QueryBuilder
 
+# Mapping of foreign key columns to referenced tables
+FK_MAP = {
+    'operatore_id': 'Specialista',
+    'consenso_operatore_id': 'Specialista',
+    'utente_id': 'Utente',
+    'specialista_id': 'Specialista',
+    'sede_id': 'Sede',
+}
+
 # Map URL segment to table name
 TABLE_MAP = {
     'users': 'Utente',
@@ -25,17 +34,45 @@ def record_view(name, rec_id):
     cur = conn.cursor(dictionary=True)
     qb = QueryBuilder(table)
 
+    # Get column types for date detection
+    cur.execute(f"SHOW COLUMNS FROM {table}")
+    cols_info = {row['Field']: row['Type'] for row in cur.fetchall()}
+    date_fields = [k for k, t in cols_info.items() if 'date' in t.lower()]
+
     # Update record when allowed
     editable = session.get('role') in ('editor', 'founder')
     if request.method == 'POST' and editable:
-        data = {k: v for k, v in request.form.items() if k != 'csrf_token'}
+        data = {}
+        for k, v in request.form.items():
+            if k == 'csrf_token':
+                continue
+            data[k] = v if v != '' else None
         sql, values = qb.update(rec_id, data)
         cur.execute(sql, values)
         conn.commit()
 
     cur.execute(qb.select_one(), (rec_id,))
     row = cur.fetchone()
-    cur.close()
     if not row:
+        cur.close()
         abort(404)
-    return render_template('record.html', row=row, name=name, editable=editable)
+
+    options = {}
+    for col, ref_table in FK_MAP.items():
+        if col in row:
+            cur.execute(
+                'SELECT column_name FROM ColumnConfig WHERE table_name=%s AND highlight=1 ORDER BY display_order',
+                (ref_table,)
+            )
+            highlight_cols = [r['column_name'] for r in cur.fetchall()]
+            cols = ['id'] + highlight_cols if highlight_cols else ['id']
+            cur.execute(f"SELECT {', '.join(cols)} FROM {ref_table}")
+            opts = []
+            for r in cur.fetchall():
+                label = ' '.join(str(r[h]) for h in highlight_cols) if highlight_cols else str(r['id'])
+                opts.append({'id': r['id'], 'label': label})
+            options[col] = opts
+
+    cur.close()
+    return render_template('record.html', row=row, name=name, editable=editable,
+                           options=options, date_fields=date_fields)

--- a/src/static/css/style.css
+++ b/src/static/css/style.css
@@ -8,6 +8,15 @@ body {
 .table-actions {
     white-space: nowrap;
 }
+
+/* minimal style for record page */
+.record-container {
+    max-width: 600px;
+    margin: 0 auto;
+    background-color: #fff;
+    padding: 20px;
+    border-radius: 4px;
+}
 .sidebar {
     position: fixed;
     top: 4.5rem;

--- a/src/static/js/main.js
+++ b/src/static/js/main.js
@@ -57,7 +57,7 @@ $(function() {
         $.getJSON('/extras/column-config/' + name, function(cfg){
             columnConfig = {};
             if(cfg.columns){
-                cfg.columns.forEach(function(c){ columnConfig[c.column_name] = {visible: c.visible, order: c.display_order}; });
+                cfg.columns.forEach(function(c){ columnConfig[c.column_name] = {visible: c.visible, order: c.display_order, highlight: c.highlight}; });
             }
             fetchData();
         });
@@ -222,10 +222,11 @@ $(function() {
         var cols = allColumns.length ? allColumns : [];
         var load = function(c){
             if(hiddenColumns.indexOf(c) !== -1) return;
-            var cfg = columnConfig[c] || {visible:true, order:0};
-            var item = $('<li class="list-group-item" data-col="'+c+'"></li>');
-            item.append('<input type="checkbox" class="form-check-input me-2" '+(cfg.visible?'checked':'')+'>');
-            item.append('<span>'+normalize(c)+'</span>');
+            var cfg = columnConfig[c] || {visible:true, order:0, highlight:false};
+            var item = $('<li class="list-group-item d-flex align-items-center" data-col="'+c+'"></li>');
+            item.append('<input type="checkbox" class="form-check-input me-2 column-visible" '+(cfg.visible?'checked':'')+'>');
+            item.append('<span class="flex-grow-1">'+normalize(c)+'</span>');
+            item.append('<input type="checkbox" class="form-check-input highlight-check ms-2" '+(cfg.highlight?'checked':'')+' title="In rilievo">');
             list.append(item);
         };
         if(cols.length){
@@ -247,7 +248,8 @@ $(function() {
         $('#columns-list li').each(function(i){
             cols.push({
                 column_name: $(this).data('col'),
-                visible: $(this).find('input').is(':checked'),
+                visible: $(this).find('.column-visible').is(':checked'),
+                highlight: $(this).find('.highlight-check').is(':checked'),
                 display_order: i
             });
 

--- a/src/templates/record.html
+++ b/src/templates/record.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% block title %}Record{% endblock %}
 {% block content %}
+<div class="record-container">
 <h2>{{ name|capitalize }} {{ row.id }}</h2>
 <form method="post">
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
@@ -8,7 +9,18 @@
     {% if key != 'id' %}
     <div class="mb-3">
       <label class="form-label">{{ key.replace('_', ' ') }}</label>
-      <input class="form-control" name="{{ key }}" value="{{ value }}" {% if not editable %}readonly{% endif %}>
+      {% if key in options %}
+        <select class="form-select" name="{{ key }}" {% if not editable %}disabled{% endif %}>
+          <option value=""></option>
+          {% for opt in options[key] %}
+          <option value="{{ opt.id }}" {% if opt.id == value %}selected{% endif %}>{{ opt.label }}</option>
+          {% endfor %}
+        </select>
+      {% elif key in date_fields %}
+        <input type="date" class="form-control" name="{{ key }}" value="{{ value if value else '' }}" {% if not editable %}readonly{% endif %}>
+      {% else %}
+        <input class="form-control" name="{{ key }}" value="{{ value if value else '' }}" {% if not editable %}readonly{% endif %}>
+      {% endif %}
     </div>
     {% endif %}
   {% endfor %}
@@ -16,4 +28,5 @@
   <button type="submit" class="btn btn-primary">Salva</button>
   {% endif %}
 </form>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- extend `ColumnConfig` with `highlight` flag
- load and save highlight info via Extras endpoints and UI
- support foreign key picklists and date fields in record view
- simplify record page appearance

## Testing
- `python -m py_compile src/modules/record.py src/modules/extras.py src/db.py`
- `python -m py_compile src/modules/*py`

------
https://chatgpt.com/codex/tasks/task_e_686d352dcb88832f9e6910a418ba34ea