### PR TITLE
Improve record editing and deletion UX

### DIFF
--- a/src/modules/sede.py
+++ b/src/modules/sede.py
@@ -1,6 +1,7 @@
 """REST API for the ``Sede`` table."""
 
 from flask import Blueprint, request, jsonify
+from mysql.connector import errors, errorcode
 from db import get_db_connection
 from .utils import login_required, role_required
 from .query_builder import QueryBuilder
@@ -108,9 +109,23 @@ def update(id):
 def delete(id):
     """Delete a record."""
     # Remove one row by id
+    force = request.args.get('force') == '1'
     conn = get_db_connection()
     cur = conn.cursor()
-    cur.execute(qb.delete(), (id,))
-    conn.commit()
+    try:
+        cur.execute(qb.delete(), (id,))
+        conn.commit()
+    except errors.IntegrityError as e:
+        if e.errno == errorcode.ER_ROW_IS_REFERENCED_2:
+            if not force:
+                cur.close()
+                return jsonify({'error': 'foreign_key'}), 409
+            cur.execute('DELETE FROM Provvedimento WHERE sede_id=%s', (id,))
+            conn.commit()
+            cur.execute(qb.delete(), (id,))
+            conn.commit()
+        else:
+            cur.close()
+            return jsonify({'error': str(e)}), 400
     cur.close()
     return jsonify({'status': 'deleted'})

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -4,8 +4,8 @@
 <div class="row">
   <div class="col-md-2">
     <ul class="list-group sidebar">
-      <li class="list-group-item table-link active" data-table="specialists">Specialisti</li>
-      <li class="list-group-item table-link" data-table="users">Utenti</li>
+      <li class="list-group-item table-link" data-table="specialists">Specialisti</li>
+      <li class="list-group-item table-link active" data-table="users">Utenti</li>
       <li class="list-group-item table-link" data-table="sedi">Sedi</li>
     </ul>
   </div>

--- a/src/templates/record.html
+++ b/src/templates/record.html
@@ -2,9 +2,10 @@
 {% block title %}Record{% endblock %}
 {% block content %}
 <div class="record-container">
-<h2>{{ name|capitalize }} {{ row.id }}</h2>
+<h2>Modifica {{ name|capitalize }}</h2>
 <form method="post">
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+  {% set readonly_fields = ['created_at', 'updated_at'] %}
   {% for key, value in row.items() %}
     {% if key != 'id' %}
     <div class="mb-3">
@@ -17,9 +18,13 @@
           {% endfor %}
         </select>
       {% elif key in date_fields %}
-        <input type="date" class="form-control" name="{{ key }}" value="{{ value if value else '' }}" {% if not editable %}readonly{% endif %}>
+        <input type="date" class="form-control" name="{{ key }}" value="{{ value if value else '' }}" {% if not editable or key in readonly_fields %}readonly{% endif %} {% if key in readonly_fields %}disabled{% endif %}>
       {% else %}
+        {% if key in readonly_fields %}
+        <input class="form-control" value="{{ value if value else '' }}" disabled>
+        {% else %}
         <input class="form-control" name="{{ key }}" value="{{ value if value else '' }}" {% if not editable %}readonly{% endif %}>
+        {% endif %}
       {% endif %}
     </div>
     {% endif %}


### PR DESCRIPTION
## Summary
- prevent editing of `created_at` and `updated_at`
- redirect back to the table view after saving a record
- show only `Modifica <risorsa>` title for record pages
- allow force deletion with cleanup of foreign key references
- default UI to the Users section and support a `?table=` query parameter
- notify the user when deletion fails due to foreign keys

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686d40b4f5c0832fa3d43aec9c6c2b9e