### PR TITLE
Improve error handling and generic FK cleanup

### DIFF
--- a/src/modules/sede.py
+++ b/src/modules/sede.py
@@ -3,7 +3,7 @@
 from flask import Blueprint, request, jsonify
 from mysql.connector import errors, errorcode
 from db import get_db_connection
-from .utils import login_required, role_required
+from .utils import login_required, role_required, remove_fk_references
 from .query_builder import QueryBuilder
 import csv
 import io
@@ -120,8 +120,8 @@ def delete(id):
             if not force:
                 cur.close()
                 return jsonify({'error': 'foreign_key'}), 409
-            cur.execute('DELETE FROM Provvedimento WHERE sede_id=%s', (id,))
-            conn.commit()
+            # remove references generically and retry
+            remove_fk_references(conn, 'Sede', id)
             cur.execute(qb.delete(), (id,))
             conn.commit()
         else:

--- a/src/templates/record.html
+++ b/src/templates/record.html
@@ -3,6 +3,9 @@
 {% block content %}
 <div class="record-container">
 <h2>Modifica {{ name|capitalize }}</h2>
+{% if error %}
+<div class="alert alert-danger">{{ error }}</div>
+{% endif %}
 <form method="post">
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   {% set readonly_fields = ['created_at', 'updated_at'] %}


### PR DESCRIPTION
## Summary
- show DB update errors on the record page
- add a utility to remove foreign key references generically
- use the new function in `Sede` and `Specialista` deletions
- expose error alerts in `record.html`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d4418b2f8832f87eedd0bd421b544