### PR TITLE
Fix force delete redirect

### DIFF
--- a/src/static/js/main.js
+++ b/src/static/js/main.js
@@ -132,7 +132,7 @@ $(function() {
             function deleteRow(row, force){
                 var data = row.data();
                 var url = endpoints[currentTable] + data.id + (force ? '?force=1' : '');
-                return $.ajax({url:url, method:'DELETE'}).fail(function(xhr){
+                return $.ajax({url:url, method:'DELETE'}).then(null, function(xhr){
                     if(!force && xhr.status === 409){
                         if(confirm('Record collegato ad altre tabelle. Eliminare comunque?')){
                             return deleteRow(row, true);


### PR DESCRIPTION
## Summary
- ensure forced record deletion does not break the AJAX promise chain

## Testing
- `python -m py_compile src/modules/*.py`

------
https://chatgpt.com/codex/tasks/task_e_686d4b39a5e8832f91da58c9d03ea857