### PR TITLE
Fix sorting defaults

### DIFF
--- a/src/modules/sede.py
+++ b/src/modules/sede.py
@@ -20,7 +20,7 @@ def list_or_search():
     query = request.args.get('query')
     page = request.args.get('page', default=1, type=int)
     per_page = request.args.get('per_page', default=50, type=int)
-    sort_by = request.args.get('sort_by', default='id')
+    sort_by = request.args.get('sort_by')
     order = request.args.get('order', default='asc').lower()
 
     conn = get_db_connection()
@@ -42,18 +42,21 @@ def list_or_search():
         clauses = ' WHERE ' + ' OR '.join(like_parts)
         values.extend(['%' + query + '%'] * len(cols))
 
-    # Validate sorting column
-    cur.execute('SHOW COLUMNS FROM Sede')
-    valid_cols = [r[0] for r in cur.fetchall()]
-    if sort_by not in valid_cols:
-        sort_by = 'id'
     order_sql = 'DESC' if order == 'desc' else 'ASC'
+    if sort_by:
+        cur.execute('SHOW COLUMNS FROM Sede')
+        valid_cols = [r[0] for r in cur.fetchall()]
+        if sort_by not in valid_cols:
+            sort_by = None
 
     count_sql = f'SELECT COUNT(*) FROM Sede{clauses}'
     cur.execute(count_sql, values)
     total = cur.fetchone()['COUNT(*)']
 
-    base_sql += f"{clauses} ORDER BY {sort_by} {order_sql} LIMIT %s OFFSET %s"
+    if sort_by:
+        base_sql += f"{clauses} ORDER BY {sort_by} {order_sql} LIMIT %s OFFSET %s"
+    else:
+        base_sql += f"{clauses} LIMIT %s OFFSET %s"
     values.extend([per_page, (page - 1) * per_page])
     cur.execute(base_sql, values)
     rows = cur.fetchall()

--- a/src/modules/specialista.py
+++ b/src/modules/specialista.py
@@ -20,7 +20,7 @@ def list_or_search():
     query = request.args.get('query')
     page = request.args.get('page', default=1, type=int)
     per_page = request.args.get('per_page', default=50, type=int)
-    sort_by = request.args.get('sort_by', default='id')
+    sort_by = request.args.get('sort_by')
     order = request.args.get('order', default='asc').lower()
 
     conn = get_db_connection()
@@ -42,18 +42,21 @@ def list_or_search():
         clauses = ' WHERE ' + ' OR '.join(like_parts)
         values.extend(['%' + query + '%'] * len(cols))
 
-    # Validate sorting column
-    cur.execute('SHOW COLUMNS FROM Specialista')
-    valid_cols = [r[0] for r in cur.fetchall()]
-    if sort_by not in valid_cols:
-        sort_by = 'id'
     order_sql = 'DESC' if order == 'desc' else 'ASC'
+    if sort_by:
+        cur.execute('SHOW COLUMNS FROM Specialista')
+        valid_cols = [r[0] for r in cur.fetchall()]
+        if sort_by not in valid_cols:
+            sort_by = None
 
     count_sql = f'SELECT COUNT(*) FROM Specialista{clauses}'
     cur.execute(count_sql, values)
     total = cur.fetchone()['COUNT(*)']
 
-    base_sql += f"{clauses} ORDER BY {sort_by} {order_sql} LIMIT %s OFFSET %s"
+    if sort_by:
+        base_sql += f"{clauses} ORDER BY {sort_by} {order_sql} LIMIT %s OFFSET %s"
+    else:
+        base_sql += f"{clauses} LIMIT %s OFFSET %s"
     values.extend([per_page, (page-1) * per_page])
     cur.execute(base_sql, values)
     rows = cur.fetchall()

--- a/src/modules/utente.py
+++ b/src/modules/utente.py
@@ -21,7 +21,7 @@ def list_or_search():
     query = request.args.get('query')
     page = request.args.get('page', default=1, type=int)
     per_page = request.args.get('per_page', default=50, type=int)
-    sort_by = request.args.get('sort_by', default='id')
+    sort_by = request.args.get('sort_by')
     order = request.args.get('order', default='asc').lower()
 
     conn = get_db_connection()
@@ -45,19 +45,22 @@ def list_or_search():
         clauses = ' WHERE ' + ' OR '.join(like_parts)
         values.extend(['%' + query + '%'] * len(cols))
 
-    # Validate sorting column
-    cur.execute('SHOW COLUMNS FROM Utente')
-    valid_cols = [r[0] for r in cur.fetchall()]
-    if sort_by not in valid_cols:
-        sort_by = 'id'
     order_sql = 'DESC' if order == 'desc' else 'ASC'
+    if sort_by:
+        cur.execute('SHOW COLUMNS FROM Utente')
+        valid_cols = [r[0] for r in cur.fetchall()]
+        if sort_by not in valid_cols:
+            sort_by = None
 
     # Total number of rows for pagination
     count_sql = f'SELECT COUNT(*) FROM Utente{clauses}'
     cur.execute(count_sql, values)
     total = cur.fetchone()['COUNT(*)']
 
-    base_sql += f"{clauses} ORDER BY {sort_by} {order_sql} LIMIT %s OFFSET %s"
+    if sort_by:
+        base_sql += f"{clauses} ORDER BY {sort_by} {order_sql} LIMIT %s OFFSET %s"
+    else:
+        base_sql += f"{clauses} LIMIT %s OFFSET %s"
     values.extend([per_page, (page - 1) * per_page])
     cur.execute(base_sql, values)
     rows = cur.fetchall()

--- a/src/static/js/main.js
+++ b/src/static/js/main.js
@@ -22,7 +22,7 @@ $(function() {
     var currentPage = 1;
     var totalPages = 1;
     var perPage = parseInt($('#per-page-select').val(), 10) || 50;
-    var sortBy = 'id';
+    var sortBy = null;
     var sortOrder = 'asc';
     var allColumns = [];
     var currentColumns = [];
@@ -57,7 +57,7 @@ $(function() {
 
     function loadTable(name) {
         currentTable = name;
-        sortBy = 'id';
+        sortBy = null;
         sortOrder = 'asc';
         currentPage = 1;
         $.getJSON('/extras/column-config/' + name, function(cfg){
@@ -69,7 +69,9 @@ $(function() {
         });
 
         function fetchData(){
-        $.getJSON(endpoints[name], {page: currentPage, per_page: perPage, query: $('#search-bar').val(), sort_by: sortBy, order: sortOrder}, function(res) {
+        var params = {page: currentPage, per_page: perPage, query: $('#search-bar').val()};
+        if(sortBy){ params.sort_by = sortBy; params.order = sortOrder; }
+        $.getJSON(endpoints[name], params, function(res) {
             var data = res.rows || res;
             totalPages = Math.max(1, Math.ceil((res.total || data.length) / perPage));
             var thead = '';


### PR DESCRIPTION
## Summary
- fix API endpoints to skip ordering when sort parameters aren't provided
- update frontend to only send sorting params when user sorts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d50351870832f8f4622d36f4e34d2